### PR TITLE
Fix scenario where expandedRowHeights[expandedOffset] is undefined, which leads to NaNs.

### DIFF
--- a/src/directives/apMesa.js
+++ b/src/directives/apMesa.js
@@ -372,7 +372,7 @@
           runningTotalScroll += rowsHeight;
 
           // the pixels that this row's expanded panel displaces
-          var expandedPixels = scope.transientState.expandedRowHeights[expandedOffset];
+          var expandedPixels = scope.transientState.expandedRowHeights[expandedOffset] || 0;
           runningTotalScroll += expandedPixels;
           rowOffset = expandedOffset;
 
@@ -383,7 +383,7 @@
           }
         }
 
-        scope.transientState.rowOffset = Math.max(0, rowOffset);
+        scope.transientState.rowOffset = Math.max(0, rowOffset || 0);
 
         scrollDeferred.resolve();
 


### PR DESCRIPTION
<img width="1138" alt="screen shot 2017-10-26 at 3 23 26 pm" src="https://user-images.githubusercontent.com/75582/32081850-98a91d9a-ba6c-11e7-998d-86b79fc18cb4.png">
